### PR TITLE
Include app icon in notifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,9 @@ $(EXE):
 
 package_app:
 	mkdir -p DS3activate.app/Contents/{MacOS,Resources}
-	cp DS3activate DS3activate.app/Contents/MacOS/DS3activate
+	cp DS3activate DS3activate.app/Contents/Resources/DS3activate
 	cp Info.plist DS3activate.app/Contents/
-	cp ds3.sh DS3activate.app/Contents/MacOS/ds3
-	chmod +x DS3activate.app/Contents/MacOS/ds3
+	swiftc ds3.swift -o DS3activate.app/Contents/MacOS/ds3
 	cp AppIcon.icns DS3activate.app/Contents/Resources 
 
 clean:

--- a/ds3.sh
+++ b/ds3.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-cd $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-if ./DS3activate | grep -q 'rumbling'
-then
-  osascript -e 'display notification "Should be rumbling!" with title "DS3activate" subtitle "DualShock 3 Enabled"'
-else
-osascript -e 'display notification with title "DS3activate" subtitle "No DualShock 3 gamepads found!"'
-fi

--- a/ds3.swift
+++ b/ds3.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+let script = """
+set appPath to quoted form of POSIX path of (path to resource "DS3activate") as text
+set output to (do shell script appPath)
+if output contains "rumbling" then
+    display notification "Should be rumbling!" with title "DS3activate" subtitle "DualShock 3 Enabled"
+else
+    display notification with title "DS3activate" subtitle "No DualShock 3 gamepads found!"
+end if
+"""
+
+NSAppleScript(source: script)!.executeAndReturnError(nil)


### PR DESCRIPTION
This PR replaces the Bash script with an AppleScript wrapped into a Swift executable to make the notifications appear with the proper app icon (instead of the Script Editor one).

### Before

<img width="350" height="78" alt="Screenshot 2025-12-30 at 01 20 22" src="https://github.com/user-attachments/assets/cf74431b-4385-4ad3-a9e2-c295a5c9a7ef" />

### After

<img width="350" height="78" alt="Screenshot 2025-12-30 at 01 20 55" src="https://github.com/user-attachments/assets/997ad25b-4ff5-4292-b86c-39c85dd1f03f" />
